### PR TITLE
Just riffing to see what this _might_ look like.

### DIFF
--- a/api/incubator/src/main/java/io/opentelemetry/api/incubator/events/DefaultEventLogger.java
+++ b/api/incubator/src/main/java/io/opentelemetry/api/incubator/events/DefaultEventLogger.java
@@ -23,6 +23,11 @@ class DefaultEventLogger implements EventLogger {
   }
 
   @Override
+  public <T> void emit(String eventName, AnyValue<T> payload, Attributes attributes){
+    // noop
+  }
+
+  @Override
   public EventBuilder builder(String eventName) {
     return NoOpEventBuilder.INSTANCE;
   }
@@ -63,5 +68,10 @@ class DefaultEventLogger implements EventLogger {
 
     @Override
     public void emit() {}
+
+    @Override
+    public <T> EventBuilder setPayload(AnyValue<T> payload) {
+      return this;
+    }
   }
 }

--- a/api/incubator/src/main/java/io/opentelemetry/api/incubator/events/EventBuilder.java
+++ b/api/incubator/src/main/java/io/opentelemetry/api/incubator/events/EventBuilder.java
@@ -108,4 +108,6 @@ public interface EventBuilder {
 
   /** Emit an event. */
   void emit();
+
+  <T> EventBuilder setPayload(AnyValue<T> payload);
 }

--- a/api/incubator/src/main/java/io/opentelemetry/api/incubator/events/EventLogger.java
+++ b/api/incubator/src/main/java/io/opentelemetry/api/incubator/events/EventLogger.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.api.incubator.events;
 
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.incubator.logs.AnyValue;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
@@ -30,6 +32,9 @@ import javax.annotation.concurrent.ThreadSafe;
  */
 @ThreadSafe
 public interface EventLogger {
+
+  <T> void emit(String eventName, AnyValue<T> payload, Attributes attributes);
+
 
   /**
    * Return a {@link EventBuilder} to emit an event.

--- a/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/internal/SdkEventBuilder.java
+++ b/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/internal/SdkEventBuilder.java
@@ -36,6 +36,13 @@ class SdkEventBuilder implements EventBuilder {
   }
 
   @Override
+  public <T> EventBuilder setPayload(AnyValue<T> payload) {
+    this.payload.clear();
+    ((ExtendedLogRecordBuilder) logRecordBuilder).setBody(payload);
+    return this;
+  }
+
+  @Override
   public EventBuilder put(String key, AnyValue<?> value) {
     payload.put(key, value);
     return this;

--- a/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/internal/SdkEventLoggerProvider.java
+++ b/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/internal/SdkEventLoggerProvider.java
@@ -5,10 +5,12 @@
 
 package io.opentelemetry.sdk.logs.internal;
 
+import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.incubator.events.EventBuilder;
 import io.opentelemetry.api.incubator.events.EventLogger;
 import io.opentelemetry.api.incubator.events.EventLoggerBuilder;
 import io.opentelemetry.api.incubator.events.EventLoggerProvider;
+import io.opentelemetry.api.incubator.logs.AnyValue;
 import io.opentelemetry.api.logs.Logger;
 import io.opentelemetry.api.logs.LoggerBuilder;
 import io.opentelemetry.api.logs.LoggerProvider;
@@ -95,6 +97,14 @@ public final class SdkEventLoggerProvider implements EventLoggerProvider {
     private SdkEventLogger(Clock clock, Logger delegateLogger) {
       this.clock = clock;
       this.delegateLogger = delegateLogger;
+    }
+
+    @Override
+    public <T> void emit(String eventName, AnyValue<T> payload, Attributes attributes) {
+      builder(eventName)
+          .setAttributes(attributes)
+          .setPayload(payload)
+          .emit();
     }
 
     @Override


### PR DESCRIPTION
I primarily wanted to see how interesting/painful it might be to set the payload to an arbitrary value or primitive (eg. `AnyValue.of(Long)` or whatever.  This was motivated by @scheler pointing out that #6813 doesn't quite match the language in the spec, and some users might have a need for this (especially in the case of `String`).

Mostly offering this here for discussion.  @jack-berg has already responded in #6813 that he'd like to add this on later, so we can definitely defer until later or until it's specifically asked for. 

At least trying this out helped me to understand that adding it on later is straightforward given the API implementation in #6813, and that we weren't making it too difficult.