### PR TITLE
Example approach of making implementations more similar

### DIFF
--- a/exporters/common/src/main/java/io/opentelemetry/exporter/internal/ExporterBuilderBasics.java
+++ b/exporters/common/src/main/java/io/opentelemetry/exporter/internal/ExporterBuilderBasics.java
@@ -1,0 +1,29 @@
+package io.opentelemetry.exporter.internal;
+
+import io.opentelemetry.sdk.common.export.MemoryMode;
+import io.opentelemetry.sdk.common.export.RetryPolicy;
+import javax.annotation.Nullable;
+import java.time.Duration;
+
+/**
+ * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
+ *  * at any time.
+ * @param <T> The specific concrete builder type
+ */
+public interface ExporterBuilderBasics<T> {
+  T setEndpoint(String endpoint);
+
+  T addHeader(String key, String value);
+
+  T setCompression(String compressionMethod);
+
+  T setTimeout(Duration timeout);
+
+  T setTrustedCertificates(byte[] trustedCertificatesPem);
+
+  T setClientTls(byte[] privateKeyPem, byte[] certificatePem);
+
+  T setRetryPolicy(@Nullable RetryPolicy retryPolicy);
+
+  T setMemoryMode(MemoryMode memoryMode);
+}

--- a/exporters/common/src/main/java/io/opentelemetry/exporter/internal/ExporterBuilderUtil.java
+++ b/exporters/common/src/main/java/io/opentelemetry/exporter/internal/ExporterBuilderUtil.java
@@ -47,8 +47,8 @@ public final class ExporterBuilderUtil {
   }
 
   /** Invoke the {@code memoryModeConsumer} with the configured {@link MemoryMode}. */
-  public static void configureExporterMemoryMode(
-      ConfigProperties config, Consumer<MemoryMode> memoryModeConsumer) {
+  public static <T> void configureExporterMemoryMode(
+      ConfigProperties config, ExporterBuilderBasics<T> builder) {
     String memoryModeStr = config.getString("otel.java.exporter.memory_mode");
     if (memoryModeStr == null) {
       return;
@@ -59,7 +59,7 @@ public final class ExporterBuilderUtil {
     } catch (IllegalArgumentException e) {
       throw new ConfigurationException("Unrecognized memory mode: " + memoryModeStr, e);
     }
-    memoryModeConsumer.accept(memoryMode);
+    builder.setMemoryMode(memoryMode);
   }
 
   /**

--- a/exporters/common/src/main/java/io/opentelemetry/exporter/internal/IncubatingExporterBuilderUtil.java
+++ b/exporters/common/src/main/java/io/opentelemetry/exporter/internal/IncubatingExporterBuilderUtil.java
@@ -27,8 +27,8 @@ import java.util.function.Consumer;
 public final class IncubatingExporterBuilderUtil {
 
   /** Invoke the {@code memoryModeConsumer} with the configured {@link MemoryMode}. */
-  public static void configureExporterMemoryMode(
-      DeclarativeConfigProperties config, Consumer<MemoryMode> memoryModeConsumer) {
+  public static <T> void configureExporterMemoryMode(
+      DeclarativeConfigProperties config, ExporterBuilderBasics<T> builder) {
     String memoryModeStr = config.getString("memory_mode");
     if (memoryModeStr == null) {
       return;
@@ -39,7 +39,7 @@ public final class IncubatingExporterBuilderUtil {
     } catch (IllegalArgumentException e) {
       throw new ConfigurationException("Unrecognized memory_mode: " + memoryModeStr, e);
     }
-    memoryModeConsumer.accept(memoryMode);
+    builder.setMemoryMode(memoryMode);
   }
 
   public static void configureOtlpAggregationTemporality(

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/logs/OtlpHttpLogRecordExporterBuilder.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/logs/OtlpHttpLogRecordExporterBuilder.java
@@ -10,6 +10,7 @@ import static java.util.Objects.requireNonNull;
 
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.metrics.MeterProvider;
+import io.opentelemetry.exporter.internal.ExporterBuilderBasics;
 import io.opentelemetry.exporter.internal.compression.Compressor;
 import io.opentelemetry.exporter.internal.compression.CompressorProvider;
 import io.opentelemetry.exporter.internal.compression.CompressorUtil;
@@ -33,7 +34,7 @@ import javax.net.ssl.X509TrustManager;
  *
  * @since 1.27.0
  */
-public final class OtlpHttpLogRecordExporterBuilder {
+public final class OtlpHttpLogRecordExporterBuilder implements ExporterBuilderBasics<OtlpHttpLogRecordExporterBuilder> {
 
   private static final String DEFAULT_ENDPOINT = "http://localhost:4318/v1/logs";
   private static final MemoryMode DEFAULT_MEMORY_MODE = MemoryMode.REUSABLE_DATA;

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/metrics/OtlpHttpMetricExporterBuilder.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/metrics/OtlpHttpMetricExporterBuilder.java
@@ -9,6 +9,7 @@ import static io.opentelemetry.api.internal.Utils.checkArgument;
 import static java.util.Objects.requireNonNull;
 
 import io.opentelemetry.api.metrics.MeterProvider;
+import io.opentelemetry.exporter.internal.ExporterBuilderBasics;
 import io.opentelemetry.exporter.internal.compression.Compressor;
 import io.opentelemetry.exporter.internal.compression.CompressorProvider;
 import io.opentelemetry.exporter.internal.compression.CompressorUtil;
@@ -38,7 +39,7 @@ import javax.net.ssl.X509TrustManager;
  *
  * @since 1.14.0
  */
-public final class OtlpHttpMetricExporterBuilder {
+public final class OtlpHttpMetricExporterBuilder implements ExporterBuilderBasics<OtlpHttpMetricExporterBuilder> {
 
   private static final String DEFAULT_ENDPOINT = "http://localhost:4318/v1/metrics";
 

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/trace/OtlpHttpSpanExporterBuilder.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/trace/OtlpHttpSpanExporterBuilder.java
@@ -10,6 +10,7 @@ import static java.util.Objects.requireNonNull;
 
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.metrics.MeterProvider;
+import io.opentelemetry.exporter.internal.ExporterBuilderBasics;
 import io.opentelemetry.exporter.internal.compression.Compressor;
 import io.opentelemetry.exporter.internal.compression.CompressorProvider;
 import io.opentelemetry.exporter.internal.compression.CompressorUtil;
@@ -33,7 +34,7 @@ import javax.net.ssl.X509TrustManager;
  *
  * @since 1.5.0
  */
-public final class OtlpHttpSpanExporterBuilder {
+public final class OtlpHttpSpanExporterBuilder implements ExporterBuilderBasics<OtlpHttpSpanExporterBuilder> {
 
   private static final String DEFAULT_ENDPOINT = "http://localhost:4318/v1/traces";
   private static final MemoryMode DEFAULT_MEMORY_MODE = MemoryMode.REUSABLE_DATA;

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/internal/OtlpGrpcLogRecordExporterComponentProvider.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/internal/OtlpGrpcLogRecordExporterComponentProvider.java
@@ -39,14 +39,7 @@ public class OtlpGrpcLogRecordExporterComponentProvider
     OtlpDeclarativeConfigUtil.configureOtlpExporterBuilder(
         DATA_TYPE_LOGS,
         config,
-        builder::setEndpoint,
-        builder::addHeader,
-        builder::setCompression,
-        builder::setTimeout,
-        builder::setTrustedCertificates,
-        builder::setClientTls,
-        builder::setRetryPolicy,
-        builder::setMemoryMode,
+        builder,
         /* isHttpProtobuf= */ false);
 
     return builder.build();

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/internal/OtlpGrpcMetricExporterComponentProvider.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/internal/OtlpGrpcMetricExporterComponentProvider.java
@@ -39,14 +39,7 @@ public class OtlpGrpcMetricExporterComponentProvider implements ComponentProvide
     OtlpDeclarativeConfigUtil.configureOtlpExporterBuilder(
         DATA_TYPE_METRICS,
         config,
-        builder::setEndpoint,
-        builder::addHeader,
-        builder::setCompression,
-        builder::setTimeout,
-        builder::setTrustedCertificates,
-        builder::setClientTls,
-        builder::setRetryPolicy,
-        builder::setMemoryMode,
+        builder,
         /* isHttpProtobuf= */ false);
     IncubatingExporterBuilderUtil.configureOtlpAggregationTemporality(
         config, builder::setAggregationTemporalitySelector);

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/internal/OtlpGrpcSpanExporterComponentProvider.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/internal/OtlpGrpcSpanExporterComponentProvider.java
@@ -38,14 +38,7 @@ public class OtlpGrpcSpanExporterComponentProvider implements ComponentProvider<
     OtlpDeclarativeConfigUtil.configureOtlpExporterBuilder(
         DATA_TYPE_TRACES,
         config,
-        builder::setEndpoint,
-        builder::addHeader,
-        builder::setCompression,
-        builder::setTimeout,
-        builder::setTrustedCertificates,
-        builder::setClientTls,
-        builder::setRetryPolicy,
-        builder::setMemoryMode,
+        builder,
         /* isHttpProtobuf= */ false);
 
     return builder.build();

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/internal/OtlpHttpLogRecordExporterComponentProvider.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/internal/OtlpHttpLogRecordExporterComponentProvider.java
@@ -39,14 +39,7 @@ public class OtlpHttpLogRecordExporterComponentProvider
     OtlpDeclarativeConfigUtil.configureOtlpExporterBuilder(
         DATA_TYPE_LOGS,
         config,
-        builder::setEndpoint,
-        builder::addHeader,
-        builder::setCompression,
-        builder::setTimeout,
-        builder::setTrustedCertificates,
-        builder::setClientTls,
-        builder::setRetryPolicy,
-        builder::setMemoryMode,
+        builder,
         /* isHttpProtobuf= */ true);
 
     return builder.build();

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/internal/OtlpHttpMetricExporterComponentProvider.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/internal/OtlpHttpMetricExporterComponentProvider.java
@@ -39,14 +39,7 @@ public class OtlpHttpMetricExporterComponentProvider implements ComponentProvide
     OtlpDeclarativeConfigUtil.configureOtlpExporterBuilder(
         DATA_TYPE_METRICS,
         config,
-        builder::setEndpoint,
-        builder::addHeader,
-        builder::setCompression,
-        builder::setTimeout,
-        builder::setTrustedCertificates,
-        builder::setClientTls,
-        builder::setRetryPolicy,
-        builder::setMemoryMode,
+        builder,
         /* isHttpProtobuf= */ true);
     IncubatingExporterBuilderUtil.configureOtlpAggregationTemporality(
         config, builder::setAggregationTemporalitySelector);

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/internal/OtlpHttpSpanExporterComponentProvider.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/internal/OtlpHttpSpanExporterComponentProvider.java
@@ -38,14 +38,7 @@ public class OtlpHttpSpanExporterComponentProvider implements ComponentProvider<
     OtlpDeclarativeConfigUtil.configureOtlpExporterBuilder(
         DATA_TYPE_TRACES,
         config,
-        builder::setEndpoint,
-        builder::addHeader,
-        builder::setCompression,
-        builder::setTimeout,
-        builder::setTrustedCertificates,
-        builder::setClientTls,
-        builder::setRetryPolicy,
-        builder::setMemoryMode,
+        builder,
         /* isHttpProtobuf= */ true);
 
     return builder.build();

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/logs/OtlpGrpcLogRecordExporterBuilder.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/logs/OtlpGrpcLogRecordExporterBuilder.java
@@ -11,6 +11,7 @@ import static java.util.Objects.requireNonNull;
 import io.grpc.ManagedChannel;
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.metrics.MeterProvider;
+import io.opentelemetry.exporter.internal.ExporterBuilderBasics;
 import io.opentelemetry.exporter.internal.compression.Compressor;
 import io.opentelemetry.exporter.internal.compression.CompressorProvider;
 import io.opentelemetry.exporter.internal.compression.CompressorUtil;
@@ -34,7 +35,7 @@ import javax.net.ssl.X509TrustManager;
  *
  * @since 1.27.0
  */
-public final class OtlpGrpcLogRecordExporterBuilder {
+public final class OtlpGrpcLogRecordExporterBuilder implements ExporterBuilderBasics<OtlpGrpcLogRecordExporterBuilder> {
 
   private static final String GRPC_SERVICE_NAME =
       "opentelemetry.proto.collector.logs.v1.LogsService";
@@ -102,6 +103,7 @@ public final class OtlpGrpcLogRecordExporterBuilder {
    * Sets the maximum time to wait for the collector to process an exported batch of logs. If unset,
    * defaults to {@value DEFAULT_TIMEOUT_SECS}s.
    */
+  @Override
   public OtlpGrpcLogRecordExporterBuilder setTimeout(Duration timeout) {
     requireNonNull(timeout, "timeout");
     delegate.setTimeout(timeout);
@@ -136,6 +138,7 @@ public final class OtlpGrpcLogRecordExporterBuilder {
    * Sets the OTLP endpoint to connect to. If unset, defaults to {@value DEFAULT_ENDPOINT_URL}. The
    * endpoint must start with either http:// or https://.
    */
+  @Override
   public OtlpGrpcLogRecordExporterBuilder setEndpoint(String endpoint) {
     requireNonNull(endpoint, "endpoint");
     delegate.setEndpoint(endpoint);
@@ -147,6 +150,7 @@ public final class OtlpGrpcLogRecordExporterBuilder {
    * method "gzip" and "none" are supported out of the box. Support for additional compression
    * methods is available by implementing {@link Compressor} and {@link CompressorProvider}.
    */
+  @Override
   public OtlpGrpcLogRecordExporterBuilder setCompression(String compressionMethod) {
     requireNonNull(compressionMethod, "compressionMethod");
     Compressor compressor = CompressorUtil.validateAndResolveCompressor(compressionMethod);
@@ -159,6 +163,7 @@ public final class OtlpGrpcLogRecordExporterBuilder {
    * should contain an X.509 certificate collection in PEM format. If not set, TLS connections will
    * use the system default trusted certificates.
    */
+  @Override
   public OtlpGrpcLogRecordExporterBuilder setTrustedCertificates(byte[] trustedCertificatesPem) {
     delegate.setTrustManagerFromCerts(trustedCertificatesPem);
     return this;
@@ -168,6 +173,7 @@ public final class OtlpGrpcLogRecordExporterBuilder {
    * Sets ths client key and the certificate chain to use for verifying client when TLS is enabled.
    * The key must be PKCS8, and both must be in PEM format.
    */
+  @Override
   public OtlpGrpcLogRecordExporterBuilder setClientTls(
       byte[] privateKeyPem, byte[] certificatePem) {
     delegate.setKeyManagerFromCerts(privateKeyPem, certificatePem);
@@ -194,6 +200,7 @@ public final class OtlpGrpcLogRecordExporterBuilder {
    * @param value header value
    * @return this builder's instance
    */
+  @Override
   public OtlpGrpcLogRecordExporterBuilder addHeader(String key, String value) {
     delegate.addConstantHeader(key, value);
     return this;
@@ -217,6 +224,7 @@ public final class OtlpGrpcLogRecordExporterBuilder {
    *
    * @since 1.28.0
    */
+  @Override
   public OtlpGrpcLogRecordExporterBuilder setRetryPolicy(@Nullable RetryPolicy retryPolicy) {
     delegate.setRetryPolicy(retryPolicy);
     return this;
@@ -253,6 +261,7 @@ public final class OtlpGrpcLogRecordExporterBuilder {
    *
    * @since 1.39.0
    */
+  @Override
   public OtlpGrpcLogRecordExporterBuilder setMemoryMode(MemoryMode memoryMode) {
     requireNonNull(memoryMode, "memoryMode");
     this.memoryMode = memoryMode;

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/metrics/OtlpGrpcMetricExporterBuilder.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/metrics/OtlpGrpcMetricExporterBuilder.java
@@ -10,6 +10,7 @@ import static java.util.Objects.requireNonNull;
 
 import io.grpc.ManagedChannel;
 import io.opentelemetry.api.metrics.MeterProvider;
+import io.opentelemetry.exporter.internal.ExporterBuilderBasics;
 import io.opentelemetry.exporter.internal.compression.Compressor;
 import io.opentelemetry.exporter.internal.compression.CompressorProvider;
 import io.opentelemetry.exporter.internal.compression.CompressorUtil;
@@ -39,7 +40,7 @@ import javax.net.ssl.X509TrustManager;
  *
  * @since 1.14.0
  */
-public final class OtlpGrpcMetricExporterBuilder {
+public final class OtlpGrpcMetricExporterBuilder implements ExporterBuilderBasics<OtlpGrpcMetricExporterBuilder> {
 
   private static final String GRPC_SERVICE_NAME =
       "opentelemetry.proto.collector.metrics.v1.MetricsService";
@@ -116,6 +117,7 @@ public final class OtlpGrpcMetricExporterBuilder {
    * Sets the maximum time to wait for the collector to process an exported batch of metrics. If
    * unset, defaults to {@value DEFAULT_TIMEOUT_SECS}s.
    */
+  @Override
   public OtlpGrpcMetricExporterBuilder setTimeout(Duration timeout) {
     requireNonNull(timeout, "timeout");
     delegate.setTimeout(timeout);
@@ -150,6 +152,7 @@ public final class OtlpGrpcMetricExporterBuilder {
    * Sets the OTLP endpoint to connect to. If unset, defaults to {@value DEFAULT_ENDPOINT_URL}. The
    * endpoint must start with either http:// or https://.
    */
+  @Override
   public OtlpGrpcMetricExporterBuilder setEndpoint(String endpoint) {
     requireNonNull(endpoint, "endpoint");
     delegate.setEndpoint(endpoint);
@@ -161,6 +164,7 @@ public final class OtlpGrpcMetricExporterBuilder {
    * method "gzip" and "none" are supported out of the box. Support for additional compression
    * methods is available by implementing {@link Compressor} and {@link CompressorProvider}.
    */
+  @Override
   public OtlpGrpcMetricExporterBuilder setCompression(String compressionMethod) {
     requireNonNull(compressionMethod, "compressionMethod");
     Compressor compressor = CompressorUtil.validateAndResolveCompressor(compressionMethod);
@@ -173,6 +177,7 @@ public final class OtlpGrpcMetricExporterBuilder {
    * should contain an X.509 certificate collection in PEM format. If not set, TLS connections will
    * use the system default trusted certificates.
    */
+  @Override
   public OtlpGrpcMetricExporterBuilder setTrustedCertificates(byte[] trustedCertificatesPem) {
     delegate.setTrustManagerFromCerts(trustedCertificatesPem);
     return this;
@@ -182,6 +187,7 @@ public final class OtlpGrpcMetricExporterBuilder {
    * Sets ths client key and the certificate chain to use for verifying client when TLS is enabled.
    * The key must be PKCS8, and both must be in PEM format.
    */
+  @Override
   public OtlpGrpcMetricExporterBuilder setClientTls(byte[] privateKeyPem, byte[] certificatePem) {
     delegate.setKeyManagerFromCerts(privateKeyPem, certificatePem);
     return this;
@@ -209,6 +215,7 @@ public final class OtlpGrpcMetricExporterBuilder {
    * @param value header value
    * @return this builder's instance
    */
+  @Override
   public OtlpGrpcMetricExporterBuilder addHeader(String key, String value) {
     delegate.addConstantHeader(key, value);
     return this;
@@ -263,6 +270,7 @@ public final class OtlpGrpcMetricExporterBuilder {
    *
    * @since 1.28.0
    */
+  @Override
   public OtlpGrpcMetricExporterBuilder setRetryPolicy(@Nullable RetryPolicy retryPolicy) {
     delegate.setRetryPolicy(retryPolicy);
     return this;
@@ -281,6 +289,7 @@ public final class OtlpGrpcMetricExporterBuilder {
    *
    * @since 1.39.0
    */
+  @Override
   public OtlpGrpcMetricExporterBuilder setMemoryMode(MemoryMode memoryMode) {
     requireNonNull(memoryMode, "memoryMode");
     this.memoryMode = memoryMode;

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/trace/OtlpGrpcSpanExporterBuilder.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/trace/OtlpGrpcSpanExporterBuilder.java
@@ -11,6 +11,7 @@ import static java.util.Objects.requireNonNull;
 import io.grpc.ManagedChannel;
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.metrics.MeterProvider;
+import io.opentelemetry.exporter.internal.ExporterBuilderBasics;
 import io.opentelemetry.exporter.internal.compression.Compressor;
 import io.opentelemetry.exporter.internal.compression.CompressorProvider;
 import io.opentelemetry.exporter.internal.compression.CompressorUtil;
@@ -30,7 +31,7 @@ import javax.net.ssl.SSLContext;
 import javax.net.ssl.X509TrustManager;
 
 /** Builder utility for this exporter. */
-public final class OtlpGrpcSpanExporterBuilder {
+public final class OtlpGrpcSpanExporterBuilder implements ExporterBuilderBasics<OtlpGrpcSpanExporterBuilder> {
 
   // Visible for testing
   static final String GRPC_SERVICE_NAME = "opentelemetry.proto.collector.trace.v1.TraceService";
@@ -98,6 +99,7 @@ public final class OtlpGrpcSpanExporterBuilder {
    * Sets the maximum time to wait for the collector to process an exported batch of spans. If
    * unset, defaults to {@value DEFAULT_TIMEOUT_SECS}s.
    */
+  @Override
   public OtlpGrpcSpanExporterBuilder setTimeout(Duration timeout) {
     requireNonNull(timeout, "timeout");
     delegate.setTimeout(timeout);
@@ -132,6 +134,7 @@ public final class OtlpGrpcSpanExporterBuilder {
    * Sets the OTLP endpoint to connect to. If unset, defaults to {@value DEFAULT_ENDPOINT_URL}. The
    * endpoint must start with either http:// or https://.
    */
+  @Override
   public OtlpGrpcSpanExporterBuilder setEndpoint(String endpoint) {
     requireNonNull(endpoint, "endpoint");
     delegate.setEndpoint(endpoint);
@@ -143,6 +146,7 @@ public final class OtlpGrpcSpanExporterBuilder {
    * method "gzip" and "none" are supported out of the box. Support for additional compression
    * methods is available by implementing {@link Compressor} and {@link CompressorProvider}.
    */
+  @Override
   public OtlpGrpcSpanExporterBuilder setCompression(String compressionMethod) {
     requireNonNull(compressionMethod, "compressionMethod");
     Compressor compressor = CompressorUtil.validateAndResolveCompressor(compressionMethod);
@@ -155,6 +159,7 @@ public final class OtlpGrpcSpanExporterBuilder {
    * should contain an X.509 certificate collection in PEM format. If not set, TLS connections will
    * use the system default trusted certificates.
    */
+  @Override
   public OtlpGrpcSpanExporterBuilder setTrustedCertificates(byte[] trustedCertificatesPem) {
     delegate.setTrustManagerFromCerts(trustedCertificatesPem);
     return this;
@@ -164,6 +169,7 @@ public final class OtlpGrpcSpanExporterBuilder {
    * Sets ths client key and the certificate chain to use for verifying client when TLS is enabled.
    * The key must be PKCS8, and both must be in PEM format.
    */
+  @Override
   public OtlpGrpcSpanExporterBuilder setClientTls(byte[] privateKeyPem, byte[] certificatePem) {
     delegate.setKeyManagerFromCerts(privateKeyPem, certificatePem);
     return this;
@@ -191,6 +197,7 @@ public final class OtlpGrpcSpanExporterBuilder {
    * @param value header value
    * @return this builder's instance
    */
+  @Override
   public OtlpGrpcSpanExporterBuilder addHeader(String key, String value) {
     delegate.addConstantHeader(key, value);
     return this;
@@ -214,6 +221,7 @@ public final class OtlpGrpcSpanExporterBuilder {
    *
    * @since 1.28.0
    */
+  @Override
   public OtlpGrpcSpanExporterBuilder setRetryPolicy(@Nullable RetryPolicy retryPolicy) {
     delegate.setRetryPolicy(retryPolicy);
     return this;
@@ -250,6 +258,7 @@ public final class OtlpGrpcSpanExporterBuilder {
    *
    * @since 1.39.0
    */
+  @Override
   public OtlpGrpcSpanExporterBuilder setMemoryMode(MemoryMode memoryMode) {
     requireNonNull(memoryMode, "memoryMode");
     this.memoryMode = memoryMode;

--- a/sdk-extensions/incubator/build.gradle.kts
+++ b/sdk-extensions/incubator/build.gradle.kts
@@ -37,6 +37,7 @@ dependencies {
   testImplementation(project(":exporters:logging-otlp"))
   testImplementation(project(":exporters:otlp:all"))
   testImplementation(project(":exporters:prometheus"))
+  testImplementation(project(":exporters:common"))
   testImplementation(project(":exporters:zipkin"))
   testImplementation(project(":sdk-extensions:jaeger-remote-sampler"))
   testImplementation(project(":extensions:trace-propagators"))


### PR DESCRIPTION
A quick hack to show, as an example, the commonality between the typed exporter builders. 

This is mostly a response to @zeitlinger's comment [here](https://github.com/open-telemetry/opentelemetry-java/pull/7064#discussion_r2039054526). With the interface, the implementations become very similar and maybe this helps show how they might/could/should be combined.

I also like that it makes the method that takes a ton of generic functional args more expressive.

It's incomplete, just meaning to demonstrate an idea.