### PR TITLE
Introduce DeclarativeConfigResult to eliminate reflection in IncubatingUtil

### DIFF
--- a/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/IncubatingUtil.java
+++ b/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/IncubatingUtil.java
@@ -10,17 +10,13 @@ import static java.util.Objects.requireNonNull;
 import io.opentelemetry.api.incubator.config.DeclarativeConfigException;
 import io.opentelemetry.common.ComponentLoader;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigurationException;
+import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.DeclarativeConfigResult;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.DeclarativeConfiguration;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.DeclarativeConfigurationProvider;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.OpenTelemetryConfigurationModel;
-import io.opentelemetry.sdk.internal.ExtendedOpenTelemetrySdk;
-import io.opentelemetry.sdk.metrics.SdkMeterProvider;
-import io.opentelemetry.sdk.metrics.internal.state.MeterProviderSharedState;
-import io.opentelemetry.sdk.resources.Resource;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.lang.reflect.Field;
 import java.util.logging.Logger;
 import javax.annotation.Nullable;
 
@@ -66,22 +62,11 @@ final class IncubatingUtil {
 
   private static AutoConfiguredOpenTelemetrySdk create(
       OpenTelemetryConfigurationModel model, ComponentLoader componentLoader) {
-    ExtendedOpenTelemetrySdk sdk;
     try {
-      sdk = DeclarativeConfiguration.create(model, componentLoader);
+      DeclarativeConfigResult result = DeclarativeConfiguration.create(model, componentLoader);
+      return AutoConfiguredOpenTelemetrySdk.create(result.getSdk(), result.getResource(), null);
     } catch (DeclarativeConfigException e) {
       throw toConfigurationException(e);
-    }
-
-    try {
-      Field sharedState = SdkMeterProvider.class.getDeclaredField("sharedState");
-      sharedState.setAccessible(true);
-      Resource resource =
-          ((MeterProviderSharedState) sharedState.get(sdk.getSdkMeterProvider())).getResource();
-
-      return AutoConfiguredOpenTelemetrySdk.create(sdk, resource, null);
-    } catch (NoSuchFieldException | IllegalAccessException e) {
-      throw new ConfigurationException("Error resolving resource from ExtendedOpenTelemetrySdk", e);
     }
   }
 

--- a/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/DeclarativeConfigContext.java
+++ b/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/DeclarativeConfigContext.java
@@ -14,6 +14,7 @@ import io.opentelemetry.sdk.autoconfigure.spi.internal.AutoConfigureListener;
 import io.opentelemetry.sdk.autoconfigure.spi.internal.ComponentProvider;
 import io.opentelemetry.sdk.autoconfigure.spi.internal.ExtendedDeclarativeConfigProperties;
 import io.opentelemetry.sdk.common.InternalTelemetryVersion;
+import io.opentelemetry.sdk.resources.Resource;
 import java.io.Closeable;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -41,6 +42,7 @@ class DeclarativeConfigContext implements ComponentLoader {
       Collections.newSetFromMap(new IdentityHashMap<>());
   private final List<Closeable> closeables = new ArrayList<>();
   @Nullable private volatile MeterProvider meterProvider;
+  @Nullable private Resource resource;
   @Nullable private ConfigProvider configProvider;
   @Nullable private List<ComponentProvider> componentProviders = null;
   @Nullable private DeclarativeConfigurationBuilder builder;
@@ -65,6 +67,14 @@ class DeclarativeConfigContext implements ComponentLoader {
 
   List<Closeable> getCloseables() {
     return Collections.unmodifiableList(closeables);
+  }
+
+  void setResource(Resource resource) {
+    this.resource = resource;
+  }
+
+  Resource getResource() {
+    return Objects.requireNonNull(resource, "resource has not been set");
   }
 
   public void setMeterProvider(MeterProvider meterProvider) {

--- a/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/DeclarativeConfiguration.java
+++ b/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/DeclarativeConfiguration.java
@@ -16,6 +16,7 @@ import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.autoconfigure.spi.Ordered;
 import io.opentelemetry.sdk.autoconfigure.spi.internal.AutoConfigureListener;
 import io.opentelemetry.sdk.autoconfigure.spi.internal.ComponentProvider;
+import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.DeclarativeConfigResult;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.OpenTelemetryConfigurationModel;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.SamplerModel;
 import io.opentelemetry.sdk.internal.ExtendedOpenTelemetrySdk;
@@ -124,7 +125,7 @@ public final class DeclarativeConfiguration {
    *
    * @throws DeclarativeConfigException if unable to parse or interpret
    */
-  public static ExtendedOpenTelemetrySdk parseAndCreate(InputStream inputStream) {
+  public static DeclarativeConfigResult parseAndCreate(InputStream inputStream) {
     OpenTelemetryConfigurationModel configurationModel = parse(inputStream);
     return create(configurationModel);
   }
@@ -134,10 +135,10 @@ public final class DeclarativeConfiguration {
    * corresponding to the configuration.
    *
    * @param configurationModel the configuration model
-   * @return the {@link OpenTelemetrySdk}
+   * @return the {@link DeclarativeConfigResult}
    * @throws DeclarativeConfigException if unable to interpret
    */
-  public static ExtendedOpenTelemetrySdk create(
+  public static DeclarativeConfigResult create(
       OpenTelemetryConfigurationModel configurationModel) {
     return create(configurationModel, DEFAULT_COMPONENT_LOADER);
   }
@@ -149,15 +150,15 @@ public final class DeclarativeConfiguration {
    * @param configurationModel the configuration model
    * @param componentLoader the component loader used to load {@link ComponentProvider}
    *     implementations
-   * @return the {@link OpenTelemetrySdk}
+   * @return the {@link DeclarativeConfigResult}
    * @throws DeclarativeConfigException if unable to interpret
    */
-  public static ExtendedOpenTelemetrySdk create(
+  public static DeclarativeConfigResult create(
       OpenTelemetryConfigurationModel configurationModel, ComponentLoader componentLoader) {
     return create(configurationModel, new DeclarativeConfigContext(componentLoader));
   }
 
-  private static ExtendedOpenTelemetrySdk create(
+  private static DeclarativeConfigResult create(
       OpenTelemetryConfigurationModel configurationModel, DeclarativeConfigContext context) {
     DeclarativeConfigurationBuilder builder = new DeclarativeConfigurationBuilder();
     context.setBuilder(builder);
@@ -173,7 +174,7 @@ public final class DeclarativeConfiguration {
             context,
             builder.customizeModel(configurationModel));
     callAutoConfigureListeners(context, sdk);
-    return sdk;
+    return new DeclarativeConfigResult(sdk, context.getResource());
   }
 
   /**

--- a/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/OpenTelemetryConfigurationFactory.java
+++ b/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/OpenTelemetryConfigurationFactory.java
@@ -64,6 +64,7 @@ final class OpenTelemetryConfigurationFactory
     }
 
     if (Objects.equals(true, model.getDisabled())) {
+      context.setResource(Resource.getDefault());
       return (ExtendedOpenTelemetrySdk) builder.build();
     }
 
@@ -76,6 +77,7 @@ final class OpenTelemetryConfigurationFactory
     if (model.getResource() != null) {
       resource = ResourceFactory.getInstance().create(model.getResource(), context);
     }
+    context.setResource(resource);
 
     MeterProviderModel meterProviderModel = model.getMeterProvider();
     if (meterProviderModel == null) {

--- a/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/internal/DeclarativeConfigResult.java
+++ b/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/internal/DeclarativeConfigResult.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.extension.incubator.fileconfig.internal;
+
+import io.opentelemetry.sdk.internal.ExtendedOpenTelemetrySdk;
+import io.opentelemetry.sdk.resources.Resource;
+
+/**
+ * The result of {@link io.opentelemetry.sdk.extension.incubator.fileconfig.DeclarativeConfiguration#create}.
+ *
+ * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
+ * at any time.
+ */
+public final class DeclarativeConfigResult {
+
+  private final ExtendedOpenTelemetrySdk sdk;
+  private final Resource resource;
+
+  public DeclarativeConfigResult(ExtendedOpenTelemetrySdk sdk, Resource resource) {
+    this.sdk = sdk;
+    this.resource = resource;
+  }
+
+  public ExtendedOpenTelemetrySdk getSdk() {
+    return sdk;
+  }
+
+  public Resource getResource() {
+    return resource;
+  }
+}

--- a/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/DeclarativeConfigurationCreateTest.java
+++ b/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/DeclarativeConfigurationCreateTest.java
@@ -100,7 +100,8 @@ class DeclarativeConfigurationCreateTest {
         new ByteArrayInputStream(rewrittenExampleContent.getBytes(StandardCharsets.UTF_8));
 
     // Verify that file can be parsed and interpreted without error
-    assertThatCode(() -> cleanup.addCloseable(DeclarativeConfiguration.parseAndCreate(is)))
+    assertThatCode(
+            () -> cleanup.addCloseable(DeclarativeConfiguration.parseAndCreate(is).getSdk()))
         .as("Example file: " + example.getName())
         .doesNotThrowAnyException();
   }
@@ -175,10 +176,11 @@ class DeclarativeConfigurationCreateTest {
                     new SpanProcessorModel().withAdditionalProperty("test", null))));
     ExtendedOpenTelemetrySdk sdk =
         DeclarativeConfiguration.create(
-            model,
-            // customizer is TestDeclarativeConfigurationCustomizerProvider
-            ComponentLoader.forClassLoader(
-                DeclarativeConfigurationCreateTest.class.getClassLoader()));
+                model,
+                // customizer is TestDeclarativeConfigurationCustomizerProvider
+                ComponentLoader.forClassLoader(
+                    DeclarativeConfigurationCreateTest.class.getClassLoader()))
+            .getSdk();
     assertThat(sdk.toString())
         .contains(
             "resource=Resource{schemaUrl=null, attributes={"


### PR DESCRIPTION
## Context

Builds on top of open-telemetry/opentelemetry-java#8242.

The `sharedState` field reflection in `IncubatingUtil` introduced in #8242 is a regression — it accesses a private internal field of `SdkMeterProvider` to extract `Resource`, which is fragile and goes against the direction discussed in open-telemetry/opentelemetry-java#7292.

## Change

Introduce `DeclarativeConfigResult` (in `fileconfig.internal` — not public API) as the return type of `DeclarativeConfiguration.create()`. It carries both the configured SDK and `Resource` as first-class values, so `IncubatingUtil` can read them directly with no reflection.

Target module structure per open-telemetry/opentelemetry-java#7292:

```
common (ComponentLoader)
  └── autoconfigure-spi (ConfigProperties, Ordered, ComponentProvider, AutoConfigureListener)
        └── sdk-config (OpenTelemetryConfigurationModel, SdkConfigProvider,
        |               DeclarativeConfiguration.create(), DeclarativeConfigContext,
        |               DeclarativeConfigurationProvider SPI,
        |               DeclarativeConfigurationCustomizer SPI)
              ├── sdk (OpenTelemetrySdk)
              ├── sdk-config-parse (DeclarativeConfiguration.parse(), Jackson/YAML)
              └── autoconfigure (invokes parse+create when OTEL_EXPERIMENTAL_CONFIG_FILE set)
```

`DeclarativeConfigResult` is the natural precursor to the result type that `create()` will need in the target architecture (where `sdk-config` cannot depend on `sdk` and must return individual providers + resource rather than an assembled `OpenTelemetrySdk`).

Does this match the target picture in open-telemetry/opentelemetry-java#7292?