### PR TITLE
Fix OSGi test setup: version syntax typo and testingBundle classpath

### DIFF
--- a/buildSrc/src/main/kotlin/otel.java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/otel.java-conventions.gradle.kts
@@ -152,7 +152,7 @@ tasks {
       // Append wildcard "*" last to import any other referenced packages
       val optionalPackages = mutableListOf("javax.annotation")
       optionalPackages.addAll(otelJava.osgiOptionalPackages.get())
-      val importPackages = optionalPackages.joinToString(",") { it + ".*;resolution:=optional;version\"\${@}\"" } + ",*"
+      val importPackages = optionalPackages.joinToString(",") { it + ".*;resolution:=optional;version=\"\${@}\"" } + ",*"
 
       bnd(mapOf(
         // Once https://github.com/open-telemetry/opentelemetry-java/issues/6970 is resolved, exclude .internal packages

--- a/integration-tests/osgi/build.gradle.kts
+++ b/integration-tests/osgi/build.gradle.kts
@@ -38,9 +38,7 @@ dependencies {
   // - with file configuration
   testImplementation(project(":sdk:all"))
 
-  // For some reason, changing this to testImplementation causes the tests to pass even when failures are present.
-  // Probably some dependency resolution interplay with otel.java-conventions but I couldn't figure it out.
-  implementation("org.junit.jupiter:junit-jupiter")
+  testImplementation("org.junit.jupiter:junit-jupiter")
 
   testCompileOnly("org.osgi:osgi.core")
   testImplementation("org.osgi:org.osgi.test.junit5")
@@ -52,6 +50,10 @@ dependencies {
 val testingBundleTask = tasks.register<Bundle>("testingBundle") {
   archiveClassifier.set("testing")
   from(sourceSets.test.get().output)
+  // The Bundle task uses compileClasspath by default for BND analysis (e.g. resolving the
+  // @Testable annotation to populate Test-Cases). Without this, testImplementation dependencies
+  // like junit-jupiter are invisible to BND, causing Test-Cases to be empty and 0 tests to run.
+  classpath(sourceSets.test.get().runtimeClasspath)
   bundle {
     bnd(
       "Test-Cases: \${classes;HIERARCHY_INDIRECTLY_ANNOTATED;org.junit.platform.commons.annotation.Testable;CONCRETE}",


### PR DESCRIPTION
Two small fixes found during review of #7964 (open-telemetry/opentelemetry-java).

## Fix 1: Missing `=` in version constraint string

In `otel.java-conventions.gradle.kts`, the Kotlin string produced `version"${@}"` instead of `version="${@}"` — a one-character typo. The test bundle in this same PR had it right; the conventions file didn't.

BND's lenient parser accepts both forms so the generated manifest is correct either way, but the code is wrong and inconsistent.

## Fix 2: `testingBundle` classpath causes silent test no-ops

The `Bundle` task uses `compileClasspath` by default for BND analysis. This means `testImplementation` dependencies are invisible to BND — including the `@Testable` annotation needed by the `Test-Cases` macro. With JUnit in `testImplementation`, BND can't resolve `@Testable`, the `Test-Cases` header comes out empty, 0 tests are discovered, and the task reports success regardless of whether any assertions would have failed.

Fix: add `classpath(sourceSets.test.get().runtimeClasspath)` to `testingBundleTask`, which makes `testImplementation` deps visible to BND and allows `junit-jupiter` to move back to `testImplementation` where it belongs.