### PR TITLE
fix: okhttp4 resource path rename and unpin hardcoded okhttp version

### DIFF
--- a/exporters/otlp/testing-internal/build.gradle.kts
+++ b/exporters/otlp/testing-internal/build.gradle.kts
@@ -27,7 +27,7 @@ dependencies {
 
   api("io.opentelemetry.proto:opentelemetry-proto")
   api("org.junit.jupiter:junit-jupiter-api")
-  implementation("com.squareup.okhttp3:okhttp:5.3.2")
+  implementation("com.squareup.okhttp3:okhttp")
   implementation("org.junit.jupiter:junit-jupiter-params")
 
   implementation("com.linecorp.armeria:armeria-grpc")

--- a/exporters/sender/okhttp4/build.gradle.kts
+++ b/exporters/sender/okhttp4/build.gradle.kts
@@ -32,6 +32,7 @@ val generateMainResources by tasks.registering(Sync::class) {
   from(okhttpDir.resolve("src/main/resources"))
   into(layout.buildDirectory.dir("generated/sources/okhttp4/main/resources"))
   filter { line: String -> line.replace("sender.okhttp.internal", "sender.okhttp4.internal") }
+  eachFile { path = path.replace("sender/okhttp/internal", "sender/okhttp4/internal") }
   includeEmptyDirs = false
 }
 


### PR DESCRIPTION
Follow-up fixes for open-telemetry/opentelemetry-java#8086.

## Changes

- **`exporters/sender/okhttp4/build.gradle.kts`**: `generateMainResources` was missing an `eachFile` path rename. Without it, `version.properties` lands at `io/opentelemetry/exporter/sender/okhttp/internal/version.properties` inside the okhttp4 jar (wrong package path). The jar listing in the PR confirms both paths are present. Added the same `eachFile` rename that `generateMainSources` and `generateTestSources` already have.

- **`exporters/otlp/testing-internal/build.gradle.kts`**: Reverts the explicit `okhttp:5.3.2` pin — `dependencyManagement` already manages the project-wide okhttp5 version, so this hardcode will drift on version bumps.