### PR TITLE
Yield collect-thread spin loops to unblock preempted recorders

### DIFF
--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/DeltaSynchronousMetricStorage.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/DeltaSynchronousMetricStorage.java
@@ -291,9 +291,11 @@ class DeltaSynchronousMetricStorage<T extends PointData>
     }
 
     /** Locks new-series creation and waits for any in-flight new-series operations to complete. */
+    @SuppressWarnings("ThreadPriorityCheck")
     void lockForCollectAndAwait() {
       int s = newSeriesGate.addAndGet(1);
       while (s != 1) {
+        Thread.yield();
         s = newSeriesGate.get();
       }
     }
@@ -350,8 +352,11 @@ class DeltaSynchronousMetricStorage<T extends PointData>
     }
 
     /** Waits for all in-flight recorders to finish, then clears the collection lock. */
+    @SuppressWarnings("ThreadPriorityCheck")
     void awaitRecordersAndUnlock() {
-      while (state.get() > 1) {}
+      while (state.get() > 1) {
+        Thread.yield();
+      }
       state.addAndGet(-1);
     }
   }


### PR DESCRIPTION
Stacked on top of open-telemetry/opentelemetry-java#8313 — targets your branch directly so it merges in if/when 8313 lands.

## Summary

Two spin loops in `DeltaSynchronousMetricStorage` busy-wait without yielding:

- `AggregatorHolder.lockForCollectAndAwait()` — waits for in-flight new-series operations
- `DeltaAggregatorHandle.awaitRecordersAndUnlock()` — waits for in-flight recorders

Recorder critical sections are short (a `LongAdder.add` for counters, bucket lookup + add for histograms), so on a roomy multi-core box the spin terminates in hundreds of cycles. But if the OS preempts a recorder mid-section, the collect thread holds its core spinning while the recorder cannot be rescheduled. Failure mode shows up on:

- Single-CPU containers (`cpus=1`)
- Pinned-core deployments
- Oversubscribed hosts where collect and recorder threads compete for the same core

Worst case stalls each handle by ~one OS quantum (~10ms), multiplied across all in-flight handles in the collection.

## Fix

Add `Thread.yield()` in both loops. Matches the existing `Thread.yield()` already used in `acquireHandleForRecord` for the holder-swap retry, so the suppression and pattern are consistent.

`Thread.onSpinWait()` would be the textbook choice (cheap PAUSE hint, JIT-friendly), but it is Java 9+. The SDK targets Java 8 via `--release 8` and animalsniffer would reject it. `Thread.yield()` is heavier but works on Java 8 and actually deschedules — which is what the constrained-CPU case needs anyway.

## Test plan

- [ ] Existing `SynchronousInstrumentStressTest` continues to pass (50× repetitions)
- [ ] Spotless + compile clean